### PR TITLE
Allow summoning the bot with mentions and per-guild custom prefixes

### DIFF
--- a/src/command/Command.js
+++ b/src/command/Command.js
@@ -4,7 +4,7 @@
  * @author Kay <kylrs00@gmail.com>
  * @license ISC - For more information, see the LICENSE.md file packaged with this file.
  * @since r20.1.0
- * @version v1.2.0
+ * @version v1.3.0
  */
 
 const fs = require('fs');
@@ -16,7 +16,6 @@ const { checkUserCanExecuteCommand } = require('../Permissions');
 module.exports = class Command {
 
     static #DEFAULT_OPTIONS = {
-        prefixes : ['gb!'],
         allowLeadingWhitespace : true,
     };
 
@@ -47,31 +46,6 @@ module.exports = class Command {
             });
     }
 
-    /**
-     * Return the longest prefix that matches the given message.
-     * If no prefix matches, return null.
-     *
-     * @author Kay <kylrs00@gmail.com>
-     * @since r20.1.0
-     *
-     * @param {Message} message
-     * @param {string[]} prefixes
-     * @returns {null|string}
-     */
-    static matchPrefix(message, prefixes) {
-        const matches = [];
-        // Find all matching prefixes
-        prefixes.forEach((prefix) => {
-            if (message.content.startsWith(prefix)) {
-                matches.push(prefix);
-            }
-        });
-
-        if (matches.length === 0) return null;
-
-        // Return the longest
-        return matches.reduce((a, b) => a.length > b.length ? a : b);
-    }
 
     /**
      * Take a Message and check if a command has been sent. If it has, execute it.
@@ -89,9 +63,9 @@ module.exports = class Command {
 
         options = Object.assign(Command.#DEFAULT_OPTIONS, options || {});
 
-        // Attempt to match a prefix, otherwise ignore the message
-        const prefix = this.matchPrefix(message, options.prefixes);
-        if (prefix === null) return;
+        // Attempt to match the guild's prefix, otherwise ignore the message
+        const prefix = client.prefixes[message.guild.id];
+        if (!message.content.startsWith(prefix)) return;
         let tail = message.content.substring(prefix.length);
 
         if (options.allowLeadingWhitespace) {

--- a/src/command/Command.js
+++ b/src/command/Command.js
@@ -4,7 +4,7 @@
  * @author Kay <kylrs00@gmail.com>
  * @license ISC - For more information, see the LICENSE.md file packaged with this file.
  * @since r20.1.0
- * @version v1.3.1
+ * @version v1.4.0
  */
 
 const fs = require('fs');
@@ -64,11 +64,16 @@ module.exports = class Command {
 
         options = Object.assign(Command.#DEFAULT_OPTIONS, options || {});
 
-        // Attempt to match the guild's prefix, otherwise ignore the message
-        const prefix = client.prefixes[message.guild.id];
-        if (!message.content.startsWith(prefix)) return;
-        let tail = message.content.substring(prefix.length);
+        // Match the guild's prefix, or the bot's tag, otherwise ignore the message
+        const regexMention = `<@!?${client.user.id}>`;
+        const gid = message.guild.id;
+        const regexPrefix = client.prefixes[gid].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+        const summoner = new RegExp(`^((${regexMention})|(${regexPrefix}))`);
+        const matches = message.content.match(summoner);
+        if (!matches) return;
+
+        let tail = message.content.substring(matches[0].length);
         if (options.allowLeadingWhitespace) {
             tail = tail.trimStart();
         }

--- a/src/command/Command.js
+++ b/src/command/Command.js
@@ -4,7 +4,7 @@
  * @author Kay <kylrs00@gmail.com>
  * @license ISC - For more information, see the LICENSE.md file packaged with this file.
  * @since r20.1.0
- * @version v1.3.0
+ * @version v1.3.1
  */
 
 const fs = require('fs');
@@ -12,6 +12,7 @@ const path = require('path');
 const { Collection, MessageEmbed } = require('discord.js');
 const ArgumentList = require('./ArgumentList.js');
 const { checkUserCanExecuteCommand } = require('../Permissions');
+const { str } = require('./arguments.js');
 
 module.exports = class Command {
 
@@ -136,16 +137,10 @@ module.exports = class Command {
     parseArgs(tail) {
         let args = new ArgumentList();
         // Only parse args if they are required
-        if (this.args) {
-            if (tail.length === 0) return new Error(`Command '${this.name}' can't be called without args.`);
+        if (this.args instanceof Object) {
 
             // If required args specify keys use them, else use numbers [0, n)
-            let names;
-            if (this.args instanceof Object) {
-                names = Object.keys(this.args);
-            } else if (Array.isArray(this.args)) {
-                names = this.args.keys();
-            }
+            const names = Object.keys(this.args);
 
             // Iterate over the required arguments, attempting to match a string that can be parsed as the given type
             for (let name of names) {
@@ -163,9 +158,12 @@ module.exports = class Command {
 
             if (tail.length > 0) return new Error(`Too many arguments!`);
         } else {
-            // If no args are required, split by whitespace and assume all tokens are of type String
+            // If args is truthy, but there is nothing to parse, throw an error
+            if (this.args && tail.length === 0) return new Error(`Command '${this.name}' can't be called without args.`);
+
+            // Split by whitespace and assume all tokens are of type String
             tail.split(/\s+/)
-                .forEach((arg, i) => args.add(i, arg, String));
+                .forEach((arg, i) => args.add(i, arg, str));
         }
 
         return args;

--- a/src/database/models/Guild.js
+++ b/src/database/models/Guild.js
@@ -4,7 +4,7 @@
  * @author Kay <kylrs00@gmail.com>
  * @license ISC - For more information, see the LICENSE.md file packaged with this file.
  * @since r20.1.0
- * @version v1.2.0
+ * @version v1.3.0
  */
 
 const mongoose = require('mongoose');
@@ -12,6 +12,10 @@ const mongoose = require('mongoose');
 const schema = new mongoose.Schema({
     id: String,
     name: String,
+    prefix: {
+        type: String,
+        default: '!',
+    },
     permissions: {
         roles: {
             type: Map,
@@ -44,6 +48,11 @@ schema.static('ensureDefaults', async function(guild) {
     if (!doc.name) {
         doc.name = guild.name;
         doc.markModified('name');
+    }
+
+    if (!doc.prefix) {
+        doc.prefix = '!';
+        doc.markModified('prefix');
     }
 
     if (!doc.permissions.roles) {

--- a/src/modules/core/commands/prefix.js
+++ b/src/modules/core/commands/prefix.js
@@ -1,0 +1,82 @@
+/**
+ * Set the prefix used to execute bot commands from text chat.
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+const { MessageEmbed } = require('discord.js');
+const Command = require('../../../command/Command.js');
+const { optional, str } = require('../../../command/arguments.js');
+
+module.exports = class PrefixCommand extends Command {
+
+    /**
+     * PrefixCommand constructor
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     */
+    constructor() {
+        super("prefix", "Set the prefix used to summon GaGBOT.", "gagbot:core:prefix", false, [optional(str)]);
+    }
+
+    /**
+     * (Optionally) Update the guild db doc & client prefix fields, and print the prefix.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @returns {boolean}
+     */
+    async execute(client, message, args) {
+        // If a new prefix is specified
+        if (args.get(0)) {
+            const newPrefix = args.get(0);
+            // Save to db
+            const doc = await client.db.guild.findOne({ id: message.guild.id });
+            doc.prefix = newPrefix;
+            doc.markModified('prefix');
+            await doc.save((err) => {
+                if (err) {
+                    message.channel.send(`An error occurred saving the new prefix.`);
+                    console.error(err);
+                    return;
+                }
+                // If successfully saved to db, cache in the client
+                client.prefixes[message.guild.id] = newPrefix;
+                this.sendSummons(client, message);
+            });
+        } else {
+            this.sendSummons(client, message);
+        }
+
+        return true;
+    }
+
+    /**
+     * Send an Embed containing instructions on how to summon the bot
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     */
+    sendSummons(client, message) {
+        message.channel.send(new MessageEmbed()
+            .setTitle('Command Prefix')
+            .setDescription('You can summon me using either:')
+            .addFields(
+                { name: 'Prefix', value: '`' + client.prefixes[message.guild.id] + '`', inline: true},
+                { name: 'Mention', value: '`@' + client.user.tag + '`', inline: true}
+            )
+            .setColor(0xEBC634)
+            .setThumbnail('https://cdn.discordapp.com/emojis/708352151558029322.png'));
+    }
+};

--- a/src/modules/core/events.js
+++ b/src/modules/core/events.js
@@ -4,7 +4,7 @@
  * @author Kay <kylrs00@gmail.com>
  * @license ISC - For more information, see the LICENSE.md file packaged with this file.
  * @since r20.0.0
- * @version v1.4.0
+ * @version v1.5.0
  */
 
 const { MessageEmbed } = require('discord.js');
@@ -23,6 +23,8 @@ module.exports = {
         console.log(`Logged in as ${client.user.tag} to guilds:`);
         for (let guild of client.guilds.cache.values()) {
             await client.db.guild.ensureDefaults(guild);
+            client.prefixes = client.prefixes ?? {};
+            client.prefixes[guild.id] = (await client.db.guild.findOne({id: guild.id})).prefix;
             console.log(`  > ${guild.name}`);
         }
     },

--- a/src/modules/core/events.js
+++ b/src/modules/core/events.js
@@ -41,10 +41,7 @@ module.exports = {
     async on_message(client, message) {
         if (message.author.bot) return;
 
-        const res = await Command.dispatchCommand(client, message, {
-            prefixes: client.config.prefixes,
-            allowLeadingWhitespace: true,
-        });
+        const res = await Command.dispatchCommand(client, message, null);
 
         if (res instanceof Error) {
             console.error(res);


### PR DESCRIPTION
**Changes:**
- Use `prefix` field in db's Guild document, or a mention of the bot, to identify a command call
- Add the `!prefix` command to `core`, for setting the prefix for the current guild
- Fix commands with only optional arguments still throw an error if no arguments are supplied

**Target:** `r20.2.0`
