### PR TITLE
Reaction Roles Module

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,5 +1,4 @@
 {
-  "prefixes" : ["!"],
   "errorMessage": "_Womp Womp_",
-  "modules": ["greet"]
+  "modules": ["greet", "reactionroles"]
 }

--- a/src/command/Command.js
+++ b/src/command/Command.js
@@ -4,7 +4,7 @@
  * @author Kay <kylrs00@gmail.com>
  * @license ISC - For more information, see the LICENSE.md file packaged with this file.
  * @since r20.1.0
- * @version v1.4.0
+ * @version v1.4.1
  */
 
 const fs = require('fs');
@@ -67,7 +67,8 @@ module.exports = class Command {
         // Match the guild's prefix, or the bot's tag, otherwise ignore the message
         const regexMention = `<@!?${client.user.id}>`;
         const gid = message.guild.id;
-        const regexPrefix = client.prefixes[gid].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const prefix = client.prefixes[gid];
+        const regexPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
         const summoner = new RegExp(`^((${regexMention})|(${regexPrefix}))`);
         const matches = message.content.match(summoner);
@@ -97,7 +98,7 @@ module.exports = class Command {
 
         // If the arguments are not invalid
         if (args instanceof Error) error = args;
-        else if (!command.execute(client, message, args)) error = new Error(`Usage Error`);
+        else if (!(await command.execute(client, message, args))) error = new Error(`Usage Error`);
 
         if (error) {
             message.channel.send(new MessageEmbed()

--- a/src/command/arguments.js
+++ b/src/command/arguments.js
@@ -4,7 +4,7 @@
  * @author Kay <kylrs00@gmail.com>
  * @license ISC - For more information, see the LICENSE.md file packaged with this file.
  * @since r20.1.0
- * @version v1.2.1
+ * @version v1.2.2
  */
 
 /**
@@ -213,7 +213,7 @@ module.exports.emoji = function emoji(input) {
 
     for (let emoji of Object.values(emojiChars)) {
         if (input.startsWith(emoji)) {
-            const rest = input.substring(emoji.length);
+            const rest = input.substring(emoji.length).trimStart();
             return [emoji, rest];
         }
     }

--- a/src/modules/reactionroles/RoleSet.js
+++ b/src/modules/reactionroles/RoleSet.js
@@ -1,0 +1,30 @@
+/**
+ * Define the Schema & init a model for RoleSet documents
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+const mongoose = require('mongoose');
+
+const schema = new mongoose.Schema({
+    guild: String,
+    channel: String,
+    message: String,
+    alias: String,
+    exclusive: {
+        type: Boolean,
+        default: false,
+    },
+    choices: {
+        type: Map,
+        of: String,
+        default: new Map(),
+    },
+});
+
+const model = mongoose.model('RoleSet', schema);
+
+module.exports = model;

--- a/src/modules/reactionroles/commands/rrbind.js
+++ b/src/modules/reactionroles/commands/rrbind.js
@@ -1,0 +1,95 @@
+/**
+ * Bind a RoleSet to a specific message
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+const Command = require('../../../command/Command.js');
+const { str, channel, id } = require('../../../command/arguments.js');
+const GagEmbed = require('../../../responses/GagEmbed.js');
+const ErrorEmbed = require('../../../responses/ErrorEmbed.js');
+
+module.exports = class ReactionRoleBindCommand extends Command {
+
+    /**
+     * ReactionRoleBindCommand constructor.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     */
+    constructor() {
+        super('rrbind', 'Bind a roleset to a message.', 'gagbot:reactionroles:bind', false, {
+            'set': str,
+            'channel': channel,
+            'message': id,
+        });
+    }
+
+    /**
+     * Bind the specified roleset to the specified message.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @returns {Promise<boolean>}
+     */
+    async execute(client, message, args) {
+
+        const setName = args.get('set');
+        const set = await client.db.roleset.findOne({guild: message.guild.id, alias: setName});
+        if (set === null) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `I couldn't find a roleset named \`${setName}\`.`));
+            return true;
+        } else if (set.message) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `This roleset is already bound to the message \`${set.message}\`.`));
+            return true;
+        }
+
+        const channelID = args.get('channel');
+        const channel = message.guild.channels.cache.get(channelID);
+        if (!channel) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `I couldn't find a channel with the ID \`${channelID}\`.`));
+            return true;
+        } else if (channel.type !== 'text') {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `I can only create react menus in text channels.`));
+            return true;
+        }
+
+        const messageID = args.get('message');
+        const reactMessage = await channel.messages.fetch(messageID);
+        if (reactMessage === null) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `I couldn't find a message with the ID \`${messageID}\`.`));
+            return true;
+        } else if (reactMessage.reactions.cache.size > 0) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `This message already has reactions. You must clear existing reactions before binding a roleset to the message.`));
+            return true;
+        }
+
+        set.channel = channelID;
+        set.message = messageID;
+        set.save((err) => {
+            if (err) {
+                message.channel.send(new ErrorEmbed(client.config.errorMessage, `Something went wrong saving the changes to the roleset.`));
+                console.error(err);
+                return;
+            }
+
+            message.channel.send(new GagEmbed(`\`${set.alias}\``, `Bound to message.`)
+                .addFields(
+                    { name: 'Message', value: messageID, inline: true },
+                    { name: 'Channel', value: channel.toString(), inline: true }
+                ));
+
+            client.emit('roleSetUpdate', set._id);
+        });
+
+        return true;
+    }
+
+};

--- a/src/modules/reactionroles/commands/rrset.js
+++ b/src/modules/reactionroles/commands/rrset.js
@@ -1,0 +1,334 @@
+/**
+ * Allow the creation and manipulation of RoleSet documents
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+const Command = require('../../../command/Command.js');
+const { choice, i, str, emoji, role, optional } = require('../../../command/arguments.js');
+const GagEmbed = require('../../../responses/GagEmbed.js');
+const ErrorEmbed = require('../../../responses/ErrorEmbed.js');
+
+
+module.exports = class ReactionRoleSetCommand extends Command {
+
+    /**
+     * ReactionRoleSetCommand constructor.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     */
+    constructor() {
+        super('rrset', 'Modify rolesets.', 'gagbot:reactionroles:set', false, {
+            'cmd': choice(i('add'), i('delete'), i('clear'), i('update'), i('list'), i('togglex')),
+            'set': str,
+            'react': optional(choice(emoji, str)),
+            'role': optional(role),
+        });
+    }
+
+    /**
+     * Take a string, and if it looks like an emoji short-form, try to get that emoji from those available to the client.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param client
+     * @param react
+     * @returns {string|null}
+     */
+    getGaGBOTEmoji(client, react) {
+        if (!/\$[a-z_]+/.test(react)) return null;
+        const name = react.replace('$', '');
+        const emoji = client.emojis.cache.find((emoji) => {
+            console.log(emoji.name);
+            return emoji.name === name;
+        });
+        if (emoji) return `<:${name}:${emoji.id}>`;
+        return null;
+    }
+
+    /**
+     * Find a RoleSet document for a specific guild and alias
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Guild} guild
+     * @param {String} setName
+     * @returns {Promise<Document|null>}
+     */
+    getRoleSet(client, guild, setName) {
+        return client.db.roleset.findOne({ guild: guild.id, alias: setName });
+    }
+
+    /**
+     * Create and return a RoleSet document for a specific guild and alias
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Guild} guild
+     * @param {String} setName
+     * @returns {Promise<Document|null>}
+     */
+    createRoleSet(client, guild, setName) {
+        return client.db.roleset.create({ guild: guild.id, alias: setName });
+    }
+
+    /**
+     * Create and return a RoleSet document for a specific guild and alias
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {Document} set
+     * @param {function} successCallback
+     * @returns {Promise<undefined>}
+     */
+    saveRoleSet(client, message, set, successCallback) {
+        return set.save((err) => {
+            if (err) {
+                message.channel.send(new ErrorEmbed(client.config.errorMessage, 'Something went wrong saving the roleset.'));
+                return;
+            }
+
+            if (successCallback) successCallback();
+        });
+    }
+
+    /**
+     * Delegate execution to the appropriate method for the specified sub-command
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @returns {Promise<boolean>}
+     */
+    async execute(client, message, args) {
+        const set = await this.getRoleSet(client, message.guild, args.get('set'));
+
+        if (set === null && args.get('cmd') !== 'add') {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `I couldn't find a roleset called \`${args.get('set')}\``));
+        }
+
+        switch(args.get('cmd')) {
+            case 'add':
+                return this.addChoice(client, message, args, set);
+            case 'delete':
+                return this.deleteChoice(client, message, args, set);
+            case 'update':
+                return this.updateChoice(client, message, args, set);
+            case 'clear':
+                return this.clearChoices(client, message, args, set);
+            case 'list':
+                return this.listChoices(client, message, args, set);
+            case 'togglex':
+                return this.toggleExclusive(client, message, args, set);
+
+        }
+    }
+
+    /**
+     * Add a react/role pair to the selected RoleSet document's `choices` field.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @param {Document} set
+     */
+    async addChoice(client, message, args, set) {
+
+        if (!args.get('react') || !args.get('role')) return false;
+
+        const setName = args.get('set');
+        const role = args.get('role');
+        let react = args.get('react');
+
+        if(!emoji(react)[0]) react = this.getGaGBOTEmoji(client, react);
+        if(!react) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `The string ${args.get('react')} is not a valid emoji.`));
+            return true;
+        }
+
+        if (set === null) set = await this.createRoleSet(client, message.guild, setName);
+
+        if (set.choices.has(react)) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `The emoji ${react} is already in the roleset \`${setName}\``));
+            return true;
+        }
+
+        const roleObj = message.guild.roles.cache.get(role);
+        set.choices.set(react, role);
+        set.markModified('choices');
+        this.saveRoleSet(client, message, set, () => {
+            message.channel.send(new GagEmbed(`\`${setName}\``, 'Added a new reaction role!')
+                .addFields(
+                    { name: 'React', value: react, inline: true },
+                    { name: 'Role', value: roleObj, inline: true },
+                ));
+        });
+
+        return true;
+    }
+
+    /**
+     * Delete a react/role pair from the selected RoleSet document's `choices` field.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @param {Document} set
+     */
+    async deleteChoice(client, message, args, set) {
+        if (!args.get('react')) return false;
+
+        const react = args.get('react');
+
+        if (!set.choices.has(react)) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `The roleset \`${args.get('set')}\` doesn't contain the ${react} react.`));
+            return true;
+        }
+
+        const oldRole = message.guild.roles.cache.get(set.choices.get(react));
+        set.choices.delete(react);
+        set.markModified('choices');
+        this.saveRoleSet(client, message, set, () => {
+            message.channel.send(new GagEmbed(`\`${args.get('set')}\``, 'Removed a reaction role!')
+                .addFields(
+                    { name: 'React', value: react, inline: true },
+                    { name: 'Role', value: oldRole.toString(), inline: true }
+                ));
+        });
+
+        return true;
+    }
+
+    /**
+     * Update a react/role pair that already exists in the selected RoleSet document's `choices` field.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @param {Document} set
+     */
+    async updateChoice(client, message, args, set) {
+        if (!args.get('react') || !args.get('role')) return false;
+
+        const react = args.get('react');
+        const role = args.get('role');
+
+        if (!set.choices.has(react)) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `The roleset \`${args.get('set')}\` doesn't contain the ${react} react.`));
+            return true;
+        }
+
+        const oldRole = message.guild.roles.cache.get(set.choices.get(react));
+        const newRole = message.guild.roles.cache.get(role);
+
+        set.choices.set(react, role);
+        set.markModified('choices');
+        this.saveRoleSet(client, message, set, () => {
+            message.channel.send(new GagEmbed(`\`${args.get('set')}\``, 'Updated a reaction role!')
+                .addFields(
+                    { name: 'React', value: react, inline: true },
+                    { name: 'From', value: oldRole.toString(), inline: true },
+                    { name: 'To', value: newRole.toString(), inline: true }
+                ));
+        });
+
+        return true;
+    }
+
+    /**
+     * Clear all react/role pairs from the selected RoleSet document's `choices` field.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @param {Document} set
+     */
+    async clearChoices(client, message, args, set) {
+        set.choices.clear();
+
+        set.markModified('choices');
+        this.saveRoleSet(client, message, set, () => {
+            message.channel.send(new GagEmbed(`\`${args.get('set')}\``, 'Cleared all reaction roles.'));
+        });
+
+        return true;
+    }
+
+    /**
+     * List all react/role pairs in the selected RoleSet document's `choices` field.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @param {Document} set
+     */
+    async listChoices(client, message, args, set) {
+        let msg = '';
+        if (set.choices.size === 0) {
+            msg += 'No reaction roles to show.'
+        } else {
+            set.choices.forEach((role, react) => {
+                const roleObj = message.guild.roles.cache.get(role) || '`deleted_role`';
+                msg += `${react} grants ${roleObj}\n`;
+            });
+        }
+
+        message.channel.send(new GagEmbed('`' + set.alias + '`', msg));
+
+        return true;
+    }
+
+    /**
+     * Toggle whether more than one reaction can exist for a given user at a time
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @param {Document} set
+     */
+    async toggleExclusive(client, message, args, set) {
+        set.exclusive = !set.exclusive;
+
+        set.markModified('choices');
+        this.saveRoleSet(client, message, set, () => {
+            let state = set.exclusive ? 'now' : 'no longer';
+            message.channel.send(new GagEmbed(`\`${args.get('set')}\``, `The role set is ${state} exclusive.`));
+        });
+
+        return true;
+    }
+
+};

--- a/src/modules/reactionroles/commands/rrunbind.js
+++ b/src/modules/reactionroles/commands/rrunbind.js
@@ -1,0 +1,66 @@
+/**
+ * Unbind a RoleSet from the currently bound message.
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+const Command = require('../../../command/Command.js');
+const { str } = require('../../../command/arguments.js');
+const GagEmbed = require('../../../responses/GagEmbed.js');
+const ErrorEmbed = require('../../../responses/ErrorEmbed.js');
+
+module.exports = class ReactionRoleUnBindCommand extends Command {
+
+    /**
+     * ReactionRoleUnBindCommand constructor.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     */
+    constructor() {
+        super('rrunbind', 'Unbind a roleset from it\'s bound message.', 'gagbot:reactionroles:bind', false, { 'set': str });
+    }
+
+    /**
+     * Unbind a RoleSet from it's bound message.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @returns {Promise<boolean>}
+     */
+    async execute(client, message, args) {
+
+        const setName = args.get('set');
+        const set = await client.db.roleset.findOne({guild: message.guild.id, alias: setName});
+        if (set === null) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `I couldn't find a roleset named \`${setName}\`.`));
+            return true;
+        } else if (!set.message) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `This roleset is not bound a message.`));
+            return true;
+        }
+
+        set.channel = null;
+        set.message = null;
+        set.save((err) => {
+            if (err) {
+                message.channel.send(new ErrorEmbed(client.config.errorMessage, `Something went wrong saving the changes to the roleset.`));
+                console.error(err);
+                return;
+            }
+
+            message.reactions.removeAll();
+            message.channel.send(new GagEmbed(`\`${set.alias}\``, `Unbound the roleset.`));
+        });
+
+        return true;
+    }
+
+};

--- a/src/modules/reactionroles/commands/rrupdate.js
+++ b/src/modules/reactionroles/commands/rrupdate.js
@@ -1,0 +1,63 @@
+/**
+ * Update the react menu bound to a roleset, to make sure all reacts are present, and there are no extra reacts.
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+const Command = require('../../../command/Command.js');
+const { str } = require('../../../command/arguments.js');
+const GagEmbed = require('../../../responses/GagEmbed.js');
+const ErrorEmbed = require('../../../responses/ErrorEmbed.js');
+
+module.exports = class ReactionRoleUpdateCommand extends Command {
+
+    /**
+     * ReactionRoleUpdateCommand constructor.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     */
+    constructor() {
+        super('rrupdate', 'Ensure all the correct roles are on the react menu for a given roleset.', 'gagbot:reactionroles:bind', false, { 'set': str });
+    }
+
+    /**
+     * Unbind a RoleSet from it's bound message.
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {Message} message
+     * @param {ArgumentList} args
+     * @returns {Promise<boolean>}
+     */
+    async execute(client, message, args) {
+
+        const setName = args.get('set');
+        const set = await client.db.roleset.findOne({guild: message.guild.id, alias: setName});
+        if (set === null) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `I couldn't find a roleset named \`${setName}\`.`));
+            return true;
+        } else if (!set.message) {
+            message.channel.send(new ErrorEmbed(client.config.errorMessage, `This roleset is not bound a message.`));
+            return true;
+        }
+
+        client.emit('roleSetUpdate', set.id, (err) => {
+            if (err) {
+                message.channel.send(new ErrorEmbed(client.config.errorMessage, `Something went wrong updating the reactions.`));
+                console.error(err);
+                return;
+            }
+
+            message.channel.send(new GagEmbed(`\`${set.alias}\``, `Updated the reactions.`));
+        });
+
+        return true;
+    }
+
+};

--- a/src/modules/reactionroles/events.js
+++ b/src/modules/reactionroles/events.js
@@ -1,0 +1,155 @@
+/**
+ * Define `reactionroles` module events.
+ *
+ * On client ready, load RoleSet documents from the db
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+module.exports = {
+
+    /**
+     * When the client loads:
+     * - Insert RoleSet model into client's db object
+     * - For each guild, cache reaction menu messages
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     */
+    async on_ready(client) {
+        client.db.roleset = require('./RoleSet.js');
+
+        for (let guild of client.guilds.cache.values()) {
+            const rolesets = await client.db.roleset.find({guild: guild.id});
+            for (let set of rolesets) {
+                if (set.channel && set.message) {
+                    const channel = guild.channels.cache.get(set.channel);
+                    if (channel && channel.type === 'text') channel.messages.fetch(set.message);
+                }
+            }
+
+        }
+    },
+
+    /**
+     * When a user reacts to a message, if it's a react menu, grant the corresponding role
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {MessageReaction} reaction
+     * @param {User} user
+     */
+    async on_messageReactionAdd(client, reaction, user) {
+        if (user.bot) return;
+
+        const message = reaction.message;
+        const set = await client.db.roleset.findOne({guild: message.guild.id, message: message.id});
+        const react = reaction.emoji.toString();
+        if (!set) return;
+        if (!set.choices.has(react)) {
+            reaction.remove();
+            return;
+        }
+
+        if (set.exclusive) {
+            message.reactions.cache.forEach((mr) => {
+                if (mr.emoji.toString() !== react) mr.users.remove(user.id);
+            });
+        }
+
+        const roleID = set.choices.get(react);
+        const role = getRoleFromID(message.guild, roleID);
+        if (!role) return;
+
+        const member = message.guild.members.resolve(user);
+        member.roles.add(role).catch(console.error);
+    },
+
+    /**
+     * When a user removes a reaction to a message, if it's a react menu, revoke the corresponding role
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {MessageReaction} reaction
+     * @param {User} user
+     */
+    async on_messageReactionRemove(client, reaction, user) {
+        if (user.bot) return;
+
+        const message = reaction.message;
+        const set = await client.db.roleset.findOne({guild: message.guild.id, message: message.id});
+        const react = reaction.emoji.toString();
+        if (!set) return;
+        if (!set.choices.has(react)) return;
+
+        const roleID = set.choices.get(react);
+        const role = getRoleFromID(message.guild, roleID);
+        if (!role) return;
+
+        const member = message.guild.members.resolve(user);
+        member.roles.remove(role).catch(console.error);
+    },
+
+    /**
+     * When a roleset is updated, ensure that a bound message
+     *
+     * @author Kay <kylrs00@gmail.com>
+     * @since r20.2.0
+     *
+     * @param {Client} client
+     * @param {string} id
+     * @param {function} callback
+     */
+    async on_roleSetUpdate(client, id, callback) {
+        let error = null;
+        const set = await client.db.roleset.findOne({_id: id});
+        if (!set) error = new Error(`No such roleset with _id \`${id}\`.`);
+        else {
+            if (!set.message || !set.channel) error = new Error('This set is not bound to a message. Use `rrbind` first.');
+            else {
+                const guild = client.guilds.cache.get(set.guild);
+                const channel = guild.channels.cache.get(set.channel);
+                const message = channel.messages.cache.get(set.message);
+
+                message.reactions.cache.forEach((mr) => {
+                    if (!set.choices.has(mr.emoji.toString())) mr.remove();
+                });
+
+                set.choices.forEach((role, react) => {
+                    if (react.startsWith('<')) {
+                        react = react.substring(react.lastIndexOf(':') + 1, react.length - 1);
+                    }
+                    message.react(react);
+                });
+            }
+        }
+
+        if (callback) callback(error);
+    },
+
+};
+
+/**
+ * Attempt to fetch a role by ID. If the role doesn't exist, log an error and return null.
+ *
+ * @param {Guild} guild
+ * @param {String} id
+ * @returns {Role|null}
+ */
+function getRoleFromID(guild, id) {
+    if (!guild.roles.cache.has(id)) {
+        console.error(`No such role '${id}' in guild '${guild.id}'.`);
+        return null;
+    }
+
+    return guild.roles.cache.get(id);
+}

--- a/src/responses/ErrorEmbed.js
+++ b/src/responses/ErrorEmbed.js
@@ -1,0 +1,23 @@
+/**
+ * A MessageEmbed with red colour and :gagded: thumbnail
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class ErrorEmbed extends MessageEmbed {
+
+    constructor(title, message) {
+        super();
+        this.setColor(0xff0000);
+        this.setThumbnail('https://cdn.discordapp.com/emojis/708352247804854285.png');
+        this.setTitle(title);
+        this.setDescription(message);
+    }
+
+};

--- a/src/responses/GagEmbed.js
+++ b/src/responses/GagEmbed.js
@@ -1,0 +1,23 @@
+/**
+ * A MessageEmbed with yellow colour and :gagbot: thumbnail
+ *
+ * @author Kay <kylrs00@gmail.com>
+ * @license ISC - For more information, see the LICENSE.md file packaged with this file.
+ * @since r20.2.0
+ * @version v1.0.0
+ */
+
+
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class ErrorEmbed extends MessageEmbed {
+
+    constructor(title, message) {
+        super();
+        this.setColor(0xEBC634);
+        this.setThumbnail('https://cdn.discordapp.com/emojis/708352151558029322.png');
+        this.setTitle(title);
+        this.setDescription(message);
+    }
+
+};


### PR DESCRIPTION
**Changes:**
- Implemented `rrset` command for manipulating role sets.
    - Add `RoleSet` Collection to db
- Implement `rrbind`, `rrunbind` and `rrupdate` for attaching role sets to react menu messages.
- Grant/revoke roles on message reacts
- Fixed emoji parsing (parsing an emoji left whitespace causing following argument matches to fail)
- Fixed Commands' async `execute` methods are not awaited, so usage is not displayed for falsey return types.

**Target:** `r20.2.0`

Resolves #11 
