### PR TITLE
Fix some commands generate usage messages for valid calls

### DIFF
--- a/src/modules/core/commands/permclear.js
+++ b/src/modules/core/commands/permclear.js
@@ -75,5 +75,6 @@ module.exports = class PermClearCommand extends Command {
             message.channel.send('Permissions cleared.');
         });
 
+        return true;
     }
 };

--- a/src/modules/core/commands/permset.js
+++ b/src/modules/core/commands/permset.js
@@ -78,5 +78,7 @@ module.exports = class PermSetCommand extends Command {
 
             message.channel.send('Permission set.');
         });
+
+        return true;
     }
 };

--- a/src/modules/core/commands/permunset.js
+++ b/src/modules/core/commands/permunset.js
@@ -76,5 +76,6 @@ module.exports = class PermUnsetCommand extends Command {
             message.channel.send('Permission unset.');
         });
 
+        return true;
     }
 };


### PR DESCRIPTION
**Changes:**
- Made some perms-related commands return `true` where previously they didn't return.

**Target:** `r20.2.0`
